### PR TITLE
fix typo - volt spelling of cancelled

### DIFF
--- a/functions/toShipStation.js
+++ b/functions/toShipStation.js
@@ -54,7 +54,7 @@ async function sendVoltOrdersToShipStation(req) {
                       return "awaiting_shipment";
                   case "Complete":
                       return "shipped";
-                  case "Cancelled":
+                  case "Canceled":
                       return "cancelled";
               }
           }


### PR DESCRIPTION
Volt API returns this spelling of the word `canceled`. It is likely ShipStation is not updating `orderStatus` when orders are cancelled.

![canceled](https://user-images.githubusercontent.com/31710093/96324332-2e59ff00-0fd6-11eb-9acd-6aaeaae6fea9.png)
